### PR TITLE
OPS-8870-Fix-imagePullSecrets

### DIFF
--- a/infra-sshd/templates/deployment.yaml
+++ b/infra-sshd/templates/deployment.yaml
@@ -30,10 +30,10 @@ spec:
       containers:
       - name: sshd
         image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
-        {{- with .Values.imagePullSecrets }}
-        imagePullSecrets:
-          {{- toYaml . | nindent 10 }}
-        {{- end }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 10 }}
+      {{- end }}
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 22


### PR DESCRIPTION
# Description
imagePullSecrets must be at the same level as containers.
